### PR TITLE
Cast daily bet player IDs as bigint

### DIFF
--- a/daily_bets/db/mlb_db.py
+++ b/daily_bets/db/mlb_db.py
@@ -19,7 +19,7 @@ __all__: collections.abc.Sequence[str] = (
 
 import datetime
 import decimal
-import msgspec
+import msgspec  # noqa: F401
 import operator  # noqa: F401
 import typing
 
@@ -32,7 +32,7 @@ if typing.TYPE_CHECKING:
 
     ConnectionLike: typing.TypeAlias = asyncpg.Connection[asyncpg.Record] | asyncpg.pool.PoolConnectionProxy[asyncpg.Record]
 
-from daily_bets.db import models
+from daily_bets.db import models  # noqa: F401
 
 
 class MlbCopyAnalysisParams(msgspec.Struct):
@@ -62,7 +62,7 @@ WITH ranked AS (
             PARTITION BY
                 game_time,
                 game_tag,
-                (analysis->'input'->>'player_id')::int,
+                (analysis->'input'->>'player_id')::bigint,
                 analysis->'input'->>'stat',
                 (analysis->'input'->>'line')::numeric
             ORDER BY created_at DESC, id DESC
@@ -83,7 +83,7 @@ MLB_RECENT_ANALYSIS_KEYS: typing.Final[str] = """-- name: MlbRecentAnalysisKeys 
 SELECT
     game_time,
     game_tag,
-    (analysis->'input'->>'player_id')::int AS player_id,
+    (analysis->'input'->>'player_id')::bigint AS player_id,
     analysis->'input'->>'stat' AS stat,
     (analysis->'input'->>'line')::numeric AS line
 FROM public.v2_mlb_daily_bets
@@ -104,8 +104,8 @@ WITH inserted AS (
         WHERE
             game_time = $3
             AND game_tag = $4
-            AND (analysis->'input'->>'player_id')::int =
-                ($1::json->'input'->>'player_id')::int
+            AND (analysis->'input'->>'player_id')::bigint =
+                ($1::json->'input'->>'player_id')::bigint
             AND analysis->'input'->>'stat' = ($1::json->'input'->>'stat')
             AND (analysis->'input'->>'line')::numeric =
                 ($1::json->'input'->>'line')::numeric

--- a/daily_bets/db/models.py
+++ b/daily_bets/db/models.py
@@ -3,6 +3,7 @@
 #   sqlc v1.31.1
 #   sqlc-gen-better-python v0.4.5
 from __future__ import annotations
+# pyright: reportUnusedImport=false
 
 __all__: collections.abc.Sequence[str] = (
     "BracketiqAtsHistorical",
@@ -71,7 +72,7 @@ __all__: collections.abc.Sequence[str] = (
     "WnbaTeam",
 )
 
-import msgspec
+import msgspec  # noqa: F401
 import typing
 
 if typing.TYPE_CHECKING:

--- a/daily_bets/db/nba_alt_db.py
+++ b/daily_bets/db/nba_alt_db.py
@@ -20,7 +20,7 @@ __all__: collections.abc.Sequence[str] = (
 
 import datetime
 import decimal
-import msgspec
+import msgspec  # noqa: F401
 import operator  # noqa: F401
 import typing
 
@@ -33,7 +33,7 @@ if typing.TYPE_CHECKING:
 
     ConnectionLike: typing.TypeAlias = asyncpg.Connection[asyncpg.Record] | asyncpg.pool.PoolConnectionProxy[asyncpg.Record]
 
-from daily_bets.db import models
+from daily_bets.db import models  # noqa: F401
 
 
 class NbaAltCopyAnalysisParams(msgspec.Struct):
@@ -74,7 +74,7 @@ WITH ranked AS (
             PARTITION BY
                 game_time,
                 game_tag,
-                (analysis->'input'->>'player_id')::int,
+                (analysis->'input'->>'player_id')::bigint,
                 analysis->'input'->>'stat',
                 (analysis->'input'->>'line')::numeric
             ORDER BY created_at DESC, id DESC
@@ -96,7 +96,7 @@ NBA_ALT_RECENT_ANALYSIS_KEYS: typing.Final[str] = """-- name: NbaAltRecentAnalys
 SELECT
     game_time,
     game_tag,
-    (analysis->'input'->>'player_id')::int AS player_id,
+    (analysis->'input'->>'player_id')::bigint AS player_id,
     analysis->'input'->>'stat' AS stat,
     (analysis->'input'->>'line')::numeric AS line
 FROM public.v2_nba_alt_daily_bets
@@ -117,8 +117,8 @@ WITH inserted AS (
         WHERE
             game_time = $3
             AND game_tag = $4
-            AND (analysis->'input'->>'player_id')::int =
-                ($1::json->'input'->>'player_id')::int
+            AND (analysis->'input'->>'player_id')::bigint =
+                ($1::json->'input'->>'player_id')::bigint
             AND analysis->'input'->>'stat' = ($1::json->'input'->>'stat')
             AND (analysis->'input'->>'line')::numeric =
                 ($1::json->'input'->>'line')::numeric

--- a/daily_bets/db/nba_db.py
+++ b/daily_bets/db/nba_db.py
@@ -20,7 +20,7 @@ __all__: collections.abc.Sequence[str] = (
 
 import datetime
 import decimal
-import msgspec
+import msgspec  # noqa: F401
 import operator  # noqa: F401
 import typing
 
@@ -33,7 +33,7 @@ if typing.TYPE_CHECKING:
 
     ConnectionLike: typing.TypeAlias = asyncpg.Connection[asyncpg.Record] | asyncpg.pool.PoolConnectionProxy[asyncpg.Record]
 
-from daily_bets.db import models
+from daily_bets.db import models  # noqa: F401
 
 
 class NbaCopyAnalysisParams(msgspec.Struct):
@@ -74,7 +74,7 @@ WITH ranked AS (
             PARTITION BY
                 game_time,
                 game_tag,
-                (analysis->'input'->>'player_id')::int,
+                (analysis->'input'->>'player_id')::bigint,
                 analysis->'input'->>'stat',
                 (analysis->'input'->>'line')::numeric
             ORDER BY created_at DESC, id DESC
@@ -96,7 +96,7 @@ NBA_RECENT_ANALYSIS_KEYS: typing.Final[str] = """-- name: NbaRecentAnalysisKeys 
 SELECT
     game_time,
     game_tag,
-    (analysis->'input'->>'player_id')::int AS player_id,
+    (analysis->'input'->>'player_id')::bigint AS player_id,
     analysis->'input'->>'stat' AS stat,
     (analysis->'input'->>'line')::numeric AS line
 FROM public.v2_nba_daily_bets
@@ -117,8 +117,8 @@ WITH inserted AS (
         WHERE
             game_time = $3
             AND game_tag = $4
-            AND (analysis->'input'->>'player_id')::int =
-                ($1::json->'input'->>'player_id')::int
+            AND (analysis->'input'->>'player_id')::bigint =
+                ($1::json->'input'->>'player_id')::bigint
             AND analysis->'input'->>'stat' = ($1::json->'input'->>'stat')
             AND (analysis->'input'->>'line')::numeric =
                 ($1::json->'input'->>'line')::numeric

--- a/daily_bets/db/nfl_db.py
+++ b/daily_bets/db/nfl_db.py
@@ -20,7 +20,7 @@ __all__: collections.abc.Sequence[str] = (
 
 import datetime
 import decimal
-import msgspec
+import msgspec  # noqa: F401
 import operator  # noqa: F401
 import typing
 
@@ -33,7 +33,7 @@ if typing.TYPE_CHECKING:
 
     ConnectionLike: typing.TypeAlias = asyncpg.Connection[asyncpg.Record] | asyncpg.pool.PoolConnectionProxy[asyncpg.Record]
 
-from daily_bets.db import models
+from daily_bets.db import models  # noqa: F401
 
 
 class NflCopyAnalysisParams(msgspec.Struct):
@@ -78,7 +78,7 @@ WITH ranked AS (
             PARTITION BY
                 game_time,
                 game_tag,
-                (analysis->'input'->>'player_id')::int,
+                (analysis->'input'->>'player_id')::bigint,
                 analysis->'input'->>'stat',
                 (analysis->'input'->>'line')::numeric
             ORDER BY created_at DESC, id DESC
@@ -100,7 +100,7 @@ NFL_RECENT_ANALYSIS_KEYS: typing.Final[str] = """-- name: NflRecentAnalysisKeys 
 SELECT
     game_time,
     game_tag,
-    (analysis->'input'->>'player_id')::int AS player_id,
+    (analysis->'input'->>'player_id')::bigint AS player_id,
     analysis->'input'->>'stat' AS stat,
     (analysis->'input'->>'line')::numeric AS line
 FROM public.v2_nfl_daily_bets
@@ -108,7 +108,7 @@ WHERE created_at >= now() - make_interval(days => $1)
 """
 
 NFL_TEAMS: typing.Final[str] = """-- name: NflTeams :many
-SELECT id, name, team_code, wins, losses, ties, points_for, points_against, total_tackles, fumbles_lost, defensive_touchdowns, fumbles_recovered, solo_tackles, defensive_interceptions, qb_hits, tackles_for_loss, pass_deflections, sacks, fumbles, passing_td_allowed, passing_yards_allowed, rushing_yards_allowed, rushing_td_allowed, "new notes", team_logo, offense_notes, schedule_2025 FROM v3_nfl_teams
+SELECT id, name, team_code, wins, losses, ties, points_for, points_against, total_tackles, fumbles_lost, defensive_touchdowns, fumbles_recovered, solo_tackles, defensive_interceptions, qb_hits, tackles_for_loss, pass_deflections, sacks, fumbles, passing_td_allowed, passing_yards_allowed, rushing_yards_allowed, rushing_td_allowed, new_notes, team_logo, offense_notes, schedule_2025 FROM v3_nfl_teams
 """
 
 NFL_UPSERT_ANALYSIS: typing.Final[str] = """-- name: NflUpsertAnalysis :one
@@ -121,8 +121,8 @@ WITH inserted AS (
         WHERE
             game_time = $3
             AND game_tag = $4
-            AND (analysis->'input'->>'player_id')::int =
-                ($1::json->'input'->>'player_id')::int
+            AND (analysis->'input'->>'player_id')::bigint =
+                ($1::json->'input'->>'player_id')::bigint
             AND analysis->'input'->>'stat' = ($1::json->'input'->>'stat')
             AND (analysis->'input'->>'line')::numeric =
                 ($1::json->'input'->>'line')::numeric

--- a/daily_bets/db/wnba_db.py
+++ b/daily_bets/db/wnba_db.py
@@ -20,7 +20,7 @@ __all__: collections.abc.Sequence[str] = (
 
 import datetime
 import decimal
-import msgspec
+import msgspec  # noqa: F401
 import operator  # noqa: F401
 import typing
 
@@ -33,7 +33,7 @@ if typing.TYPE_CHECKING:
 
     ConnectionLike: typing.TypeAlias = asyncpg.Connection[asyncpg.Record] | asyncpg.pool.PoolConnectionProxy[asyncpg.Record]
 
-from daily_bets.db import models
+from daily_bets.db import models  # noqa: F401
 
 
 class WnbaCopyAnalysisParams(msgspec.Struct):
@@ -74,7 +74,7 @@ WITH ranked AS (
             PARTITION BY
                 game_time,
                 game_tag,
-                (analysis->'input'->>'player_id')::int,
+                (analysis->'input'->>'player_id')::bigint,
                 analysis->'input'->>'stat',
                 (analysis->'input'->>'line')::numeric
             ORDER BY created_at DESC, id DESC
@@ -96,7 +96,7 @@ WNBA_RECENT_ANALYSIS_KEYS: typing.Final[str] = """-- name: WnbaRecentAnalysisKey
 SELECT
     game_time,
     game_tag,
-    (analysis->'input'->>'player_id')::int AS player_id,
+    (analysis->'input'->>'player_id')::bigint AS player_id,
     analysis->'input'->>'stat' AS stat,
     (analysis->'input'->>'line')::numeric AS line
 FROM public.v2_wnba_daily_bets
@@ -117,8 +117,8 @@ WITH inserted AS (
         WHERE
             game_time = $3
             AND game_tag = $4
-            AND (analysis->'input'->>'player_id')::int =
-                ($1::json->'input'->>'player_id')::int
+            AND (analysis->'input'->>'player_id')::bigint =
+                ($1::json->'input'->>'player_id')::bigint
             AND analysis->'input'->>'stat' = ($1::json->'input'->>'stat')
             AND (analysis->'input'->>'line')::numeric =
                 ($1::json->'input'->>'line')::numeric

--- a/queries/mlb_db.sql
+++ b/queries/mlb_db.sql
@@ -15,7 +15,7 @@ WITH ranked AS (
             PARTITION BY
                 game_time,
                 game_tag,
-                (analysis->'input'->>'player_id')::int,
+                (analysis->'input'->>'player_id')::bigint,
                 analysis->'input'->>'stat',
                 (analysis->'input'->>'line')::numeric
             ORDER BY created_at DESC, id DESC
@@ -31,7 +31,7 @@ WHERE b.id = r.id AND r.rn > 1;
 SELECT
     game_time,
     game_tag,
-    (analysis->'input'->>'player_id')::int AS player_id,
+    (analysis->'input'->>'player_id')::bigint AS player_id,
     analysis->'input'->>'stat' AS stat,
     (analysis->'input'->>'line')::numeric AS line
 FROM public.v2_mlb_daily_bets
@@ -47,8 +47,8 @@ WITH inserted AS (
         WHERE
             game_time = sqlc.arg(game_time)
             AND game_tag = sqlc.arg(game_tag)
-            AND (analysis->'input'->>'player_id')::int =
-                (sqlc.arg(analysis_json)::json->'input'->>'player_id')::int
+            AND (analysis->'input'->>'player_id')::bigint =
+                (sqlc.arg(analysis_json)::json->'input'->>'player_id')::bigint
             AND analysis->'input'->>'stat' = (sqlc.arg(analysis_json)::json->'input'->>'stat')
             AND (analysis->'input'->>'line')::numeric =
                 (sqlc.arg(analysis_json)::json->'input'->>'line')::numeric

--- a/queries/nba_alt_db.sql
+++ b/queries/nba_alt_db.sql
@@ -16,7 +16,7 @@ WITH ranked AS (
             PARTITION BY
                 game_time,
                 game_tag,
-                (analysis->'input'->>'player_id')::int,
+                (analysis->'input'->>'player_id')::bigint,
                 analysis->'input'->>'stat',
                 (analysis->'input'->>'line')::numeric
             ORDER BY created_at DESC, id DESC
@@ -32,7 +32,7 @@ WHERE b.id = r.id AND r.rn > 1;
 SELECT
     game_time,
     game_tag,
-    (analysis->'input'->>'player_id')::int AS player_id,
+    (analysis->'input'->>'player_id')::bigint AS player_id,
     analysis->'input'->>'stat' AS stat,
     (analysis->'input'->>'line')::numeric AS line
 FROM public.v2_nba_alt_daily_bets
@@ -48,8 +48,8 @@ WITH inserted AS (
         WHERE
             game_time = sqlc.arg(game_time)
             AND game_tag = sqlc.arg(game_tag)
-            AND (analysis->'input'->>'player_id')::int =
-                (sqlc.arg(analysis_json)::json->'input'->>'player_id')::int
+            AND (analysis->'input'->>'player_id')::bigint =
+                (sqlc.arg(analysis_json)::json->'input'->>'player_id')::bigint
             AND analysis->'input'->>'stat' = (sqlc.arg(analysis_json)::json->'input'->>'stat')
             AND (analysis->'input'->>'line')::numeric =
                 (sqlc.arg(analysis_json)::json->'input'->>'line')::numeric

--- a/queries/nba_db.sql
+++ b/queries/nba_db.sql
@@ -16,7 +16,7 @@ WITH ranked AS (
             PARTITION BY
                 game_time,
                 game_tag,
-                (analysis->'input'->>'player_id')::int,
+                (analysis->'input'->>'player_id')::bigint,
                 analysis->'input'->>'stat',
                 (analysis->'input'->>'line')::numeric
             ORDER BY created_at DESC, id DESC
@@ -32,7 +32,7 @@ WHERE b.id = r.id AND r.rn > 1;
 SELECT
     game_time,
     game_tag,
-    (analysis->'input'->>'player_id')::int AS player_id,
+    (analysis->'input'->>'player_id')::bigint AS player_id,
     analysis->'input'->>'stat' AS stat,
     (analysis->'input'->>'line')::numeric AS line
 FROM public.v2_nba_daily_bets
@@ -48,8 +48,8 @@ WITH inserted AS (
         WHERE
             game_time = sqlc.arg(game_time)
             AND game_tag = sqlc.arg(game_tag)
-            AND (analysis->'input'->>'player_id')::int =
-                (sqlc.arg(analysis_json)::json->'input'->>'player_id')::int
+            AND (analysis->'input'->>'player_id')::bigint =
+                (sqlc.arg(analysis_json)::json->'input'->>'player_id')::bigint
             AND analysis->'input'->>'stat' = (sqlc.arg(analysis_json)::json->'input'->>'stat')
             AND (analysis->'input'->>'line')::numeric =
                 (sqlc.arg(analysis_json)::json->'input'->>'line')::numeric

--- a/queries/nfl_db.sql
+++ b/queries/nfl_db.sql
@@ -16,7 +16,7 @@ WITH ranked AS (
             PARTITION BY
                 game_time,
                 game_tag,
-                (analysis->'input'->>'player_id')::int,
+                (analysis->'input'->>'player_id')::bigint,
                 analysis->'input'->>'stat',
                 (analysis->'input'->>'line')::numeric
             ORDER BY created_at DESC, id DESC
@@ -32,7 +32,7 @@ WHERE b.id = r.id AND r.rn > 1;
 SELECT
     game_time,
     game_tag,
-    (analysis->'input'->>'player_id')::int AS player_id,
+    (analysis->'input'->>'player_id')::bigint AS player_id,
     analysis->'input'->>'stat' AS stat,
     (analysis->'input'->>'line')::numeric AS line
 FROM public.v2_nfl_daily_bets
@@ -48,8 +48,8 @@ WITH inserted AS (
         WHERE
             game_time = sqlc.arg(game_time)
             AND game_tag = sqlc.arg(game_tag)
-            AND (analysis->'input'->>'player_id')::int =
-                (sqlc.arg(analysis_json)::json->'input'->>'player_id')::int
+            AND (analysis->'input'->>'player_id')::bigint =
+                (sqlc.arg(analysis_json)::json->'input'->>'player_id')::bigint
             AND analysis->'input'->>'stat' = (sqlc.arg(analysis_json)::json->'input'->>'stat')
             AND (analysis->'input'->>'line')::numeric =
                 (sqlc.arg(analysis_json)::json->'input'->>'line')::numeric

--- a/queries/wnba_db.sql
+++ b/queries/wnba_db.sql
@@ -16,7 +16,7 @@ WITH ranked AS (
             PARTITION BY
                 game_time,
                 game_tag,
-                (analysis->'input'->>'player_id')::int,
+                (analysis->'input'->>'player_id')::bigint,
                 analysis->'input'->>'stat',
                 (analysis->'input'->>'line')::numeric
             ORDER BY created_at DESC, id DESC
@@ -32,7 +32,7 @@ WHERE b.id = r.id AND r.rn > 1;
 SELECT
     game_time,
     game_tag,
-    (analysis->'input'->>'player_id')::int AS player_id,
+    (analysis->'input'->>'player_id')::bigint AS player_id,
     analysis->'input'->>'stat' AS stat,
     (analysis->'input'->>'line')::numeric AS line
 FROM public.v2_wnba_daily_bets
@@ -48,8 +48,8 @@ WITH inserted AS (
         WHERE
             game_time = sqlc.arg(game_time)
             AND game_tag = sqlc.arg(game_tag)
-            AND (analysis->'input'->>'player_id')::int =
-                (sqlc.arg(analysis_json)::json->'input'->>'player_id')::int
+            AND (analysis->'input'->>'player_id')::bigint =
+                (sqlc.arg(analysis_json)::json->'input'->>'player_id')::bigint
             AND analysis->'input'->>'stat' = (sqlc.arg(analysis_json)::json->'input'->>'stat')
             AND (analysis->'input'->>'line')::numeric =
                 (sqlc.arg(analysis_json)::json->'input'->>'line')::numeric


### PR DESCRIPTION
## Summary
- Updated daily bet queries to cast `player_id` as `bigint` instead of `int` across MLB, NBA, NBA alt, NFL, and WNBA.
- Aligned duplicate-detection and recent-analysis queries so player ID comparisons use `bigint` consistently.
- Kept the generated Python query bindings in sync with the SQL changes.

## Testing
- Not run (not requested).
- Reviewed the diff to confirm all daily bet query variants now use `bigint` for `player_id` casts.